### PR TITLE
feat: migrate contract to OpenZeppelin, add tests and CI

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -23,9 +23,6 @@ jobs:
       - uses: software-mansion/setup-scarb@v1
         with:
           tool-versions: contract_/.tool-versions
-      - uses: foundry-rs/setup-snfoundry@v3
-        with:
-          tool-versions: contract_/.tool-versions
       - name: Check Scarb Formatting
         run: scarb fmt --check
   run-test:
@@ -37,6 +34,20 @@ jobs:
       - uses: software-mansion/setup-scarb@v1
         with:
           tool-versions: contract_/.tool-versions
+      - name: Install universal sierra compiler
+        shell: bash
+        run: |
+          curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh
+          echo "/root/.local/bin" >> ${GITHUB_PATH}
+      - name: Check universal sierra compiler version
+        shell: bash
+        run: universal-sierra-compiler --version
+      # Rust is required by Starknet Foundry
+      - name: Set Up Stable Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
       - uses: foundry-rs/setup-snfoundry@v3
         with:
           tool-versions: contract_/.tool-versions

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,0 +1,44 @@
+name: Contract CI
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "contract_/**"
+  pull_request:
+    paths:
+      - "contract_/**"
+
+defaults:
+  run:
+    working-directory: contract_
+
+jobs:
+  check-fmt:
+    runs-on: ubuntu-latest
+    name: Cairo formatting
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - uses: software-mansion/setup-scarb@v1
+        with:
+          tool-versions: contract_/.tool-versions
+      - uses: foundry-rs/setup-snfoundry@v3
+        with:
+          tool-versions: contract_/.tool-versions
+      - name: Check Scarb Formatting
+        run: scarb fmt --check
+  run-test:
+    runs-on: ubuntu-latest
+    name: Cairo test
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - uses: software-mansion/setup-scarb@v1
+        with:
+          tool-versions: contract_/.tool-versions
+      - uses: foundry-rs/setup-snfoundry@v3
+        with:
+          tool-versions: contract_/.tool-versions
+      - name: Run scarb test
+        run: scarb test

--- a/contract_/.tool-versions
+++ b/contract_/.tool-versions
@@ -1,1 +1,2 @@
 starknet-foundry 0.35.1
+scarb 2.8.4

--- a/contract_/.tool-versions
+++ b/contract_/.tool-versions
@@ -1,2 +1,2 @@
 starknet-foundry 0.35.1
-scarb 2.8.4
+scarb 2.9.4

--- a/contract_/Scarb.lock
+++ b/contract_/Scarb.lock
@@ -5,8 +5,128 @@ version = 1
 name = "contract_"
 version = "0.1.0"
 dependencies = [
+ "openzeppelin",
  "snforge_std",
 ]
+
+[[package]]
+name = "openzeppelin"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:320185f3e17cf9fafda88b1ce490f5eaed0bfcc273036b56cd22ce4fb8de628f"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_finance",
+ "openzeppelin_governance",
+ "openzeppelin_introspection",
+ "openzeppelin_merkle_tree",
+ "openzeppelin_presets",
+ "openzeppelin_security",
+ "openzeppelin_token",
+ "openzeppelin_upgrades",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_access"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:a39a4ea1582916c637bf7e3aee0832c3fe1ea3a3e39191955e8dc39d08327f9b"
+dependencies = [
+ "openzeppelin_introspection",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_account"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:7e943a2de32ddca4d48e467e52790e380ab1f49c4daddbbbc4634dd930d0243f"
+dependencies = [
+ "openzeppelin_introspection",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_finance"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:9fa9e91d39b6ccdfa31eef32fdc087cd06c0269cc9c6b86e32d57f5a6997d98b"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_token",
+]
+
+[[package]]
+name = "openzeppelin_governance"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:c05add2974b3193c3a5c022b9586a84cf98c5970cdb884dcf201c77dbe359f55"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_introspection",
+ "openzeppelin_token",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_introspection"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:34e088ecf19e0b3012481a29f1fbb20e600540cb9a5db1c3002a97ebb7f5a32a"
+
+[[package]]
+name = "openzeppelin_merkle_tree"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:a5341705514a3d9beeeb39cf11464111f7355be621639740d2c5006786aa63dc"
+
+[[package]]
+name = "openzeppelin_presets"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:4eb098e2ee3ac0e67b6828115a7de62f781418beab767d4e80b54e176808369d"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_finance",
+ "openzeppelin_introspection",
+ "openzeppelin_token",
+ "openzeppelin_upgrades",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_security"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:1deb811a239c4f9cc28fc302039e2ffcb19911698a8c612487207448d70d2e6e"
+
+[[package]]
+name = "openzeppelin_token"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:33fcb84a1a76d2d3fff9302094ff564f78d45b743548fd7568c130b272473f66"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_introspection",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_upgrades"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:36f7a03e7e7111577916aacf31f88ad0053de20f33ee10b0ab3804849c3aa373"
+
+[[package]]
+name = "openzeppelin_utils"
+version = "1.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:fd348b31c4a4407add33adc3c2b8f26dca71dbd7431faaf726168f37a91db0c1"
 
 [[package]]
 name = "snforge_scarb_plugin"

--- a/contract_/Scarb.toml
+++ b/contract_/Scarb.toml
@@ -6,11 +6,12 @@ edition = "2024_07"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = "2.8.4"
+starknet = "2.9.4"
+openzeppelin = "1.0.0"
 
 [dev-dependencies]
 snforge_std = "0.35.1"
-assert_macros = "2.8.4"
+assert_macros = "2.9.4"
 
 [[target.starknet-contract]]
 sierra = true

--- a/contract_/src/erc20.cairo
+++ b/contract_/src/erc20.cairo
@@ -1,266 +1,109 @@
-use starknet::{ContractAddress};
-use super::errors;
+// SPDX-License-Identifier: MIT
+// Compatible with OpenZeppelin Contracts for Cairo ^1.0.0
+use starknet::ContractAddress;
 #[starknet::interface]
-pub trait Ierc20<ContractState> {
-    fn name(self: @ContractState) -> felt252;
-    fn symbol(self: @ContractState) -> felt252;
-    fn decimal(self: @ContractState) -> u64;
-    fn balance_of(self: @ContractState, account: ContractAddress) -> u256;
-    fn total_supply(self: @ContractState) -> u256;
-    fn approve(ref self: ContractState, spender: ContractAddress, amount: u256) -> bool;
-    fn transfer(ref self: ContractState, amount: u256, to_: ContractAddress) -> bool;
-    fn transfer_from(
-        ref self: ContractState, from_: ContractAddress, to_: ContractAddress, amount: u256
-    ) -> bool;
-    fn allowance(self: @ContractState, owner: ContractAddress, spender: ContractAddress) -> u256;
-    fn mint(ref self: ContractState, to_: ContractAddress, amount: u256);
+pub trait IMintable<ContractState> {
+    fn mint(ref self: ContractState, recipient: ContractAddress, amount: u256);
+}
+
+#[starknet::interface]
+pub trait IBurnable<ContractState> {
     fn burn(ref self: ContractState, amount: u256);
 }
 
 #[starknet::contract]
-pub mod TokenContract {
-    use starknet::event::EventEmitter;
-    use starknet::{ContractAddress, get_caller_address};
-    use starknet::contract_address_const;
-    use super::Ierc20;
-    use core::starknet::storage::{
-        StoragePointerReadAccess, StoragePointerWriteAccess, StoragePathEntry, Map
-    };
-    use super::errors::errors;
+pub mod MusicStrk {
+    use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin::upgrades::interface::IUpgradeable;
+    use openzeppelin::upgrades::UpgradeableComponent;
+    use starknet::{ClassHash, ContractAddress, get_caller_address};
 
+    use super::{IBurnable, IMintable};
+
+    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
+
+    // External
+    #[abi(embed_v0)]
+    impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+
+    // Internal
+    impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]
     struct Storage {
-        erc20_token: u256,
-        token_name: felt252,
-        token_symbol: felt252,
-        token_decimal: u64,
-        totalSupply: u256,
-        owner: ContractAddress,
-        sender: ContractAddress,
-        from: ContractAddress,
-        to: ContractAddress,
-        balances: Map<ContractAddress, u256>,
-        allowances: Map<(ContractAddress, ContractAddress), u256>,
+        #[substorage(v0)]
+        erc20: ERC20Component::Storage,
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        upgradeable: UpgradeableComponent::Storage,
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
-    enum Event {
-        Transfer: TransferEvent,
-        Approval: ApprovalEvent,
-        Mint: MintEvent,
-        Burn: BurnEvent,
+    pub enum Event {
+        MintEvent: MintEvent,
+        BurnEvent: BurnEvent,
+        #[flat]
+        ERC20Event: ERC20Component::Event,
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        UpgradeableEvent: UpgradeableComponent::Event,
     }
 
     #[derive(Drop, starknet::Event)]
-    struct TransferEvent {
-        from: ContractAddress,
-        to: ContractAddress,
-        value: u256,
+    pub struct MintEvent {
+        pub recipient: ContractAddress,
+        pub amount: u256,
     }
 
     #[derive(Drop, starknet::Event)]
-    struct ApprovalEvent {
-        owner: ContractAddress,
-        spender: ContractAddress,
-        value: u256,
-    }
-
-    #[derive(Drop, starknet::Event)]
-    struct MintEvent {
-        to: ContractAddress,
-        value: u256,
-    }
-
-    #[derive(Drop, starknet::Event)]
-    struct BurnEvent {
-        from: ContractAddress,
-        value: u256,
+    pub struct BurnEvent {
+        pub from: ContractAddress,
+        pub amount: u256,
     }
 
     #[constructor]
-    fn constructor(
-        ref self: ContractState, token_name_: felt252, token_symbol_: felt252, token_decimal_: u64
-    ) {
-        let owner: ContractAddress = get_caller_address();
-
-        self.token_name.write(token_name_);
-        self.token_symbol.write(token_symbol_);
-        self.token_decimal.write(token_decimal_);
-        self.owner.write(owner);
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.erc20.initializer("MusicStrk", "MSTRK");
+        self.ownable.initializer(owner);
     }
 
     #[abi(embed_v0)]
-    impl erc20Impl of Ierc20<ContractState> {
-        fn name(self: @ContractState) -> felt252 {
-            self.token_name.read()
-        }
-
-        fn symbol(self: @ContractState) -> felt252 {
-            self.token_symbol.read()
-        }
-
-        fn decimal(self: @ContractState) -> u64 {
-            self.token_decimal.read()
-        }
-
-        fn balance_of(self: @ContractState, account: ContractAddress) -> u256 {
-            self.balances.entry(account).read()
-        }
-
-        fn total_supply(self: @ContractState) -> u256 {
-            self.totalSupply.read()
-        }
-
-        fn approve(ref self: ContractState, spender: ContractAddress, amount: u256) -> bool {
-            let owner: ContractAddress = get_caller_address();
-
-            let zero_address = contract_address_const::<0x0>();
-
-            assert(owner != zero_address, errors::OWNER_ZERO_ADDRESS);
-
-            assert(spender != zero_address, errors::INVALID_SENDER);
-
-            self.allowances.entry((owner, spender)).write(amount);
-
-            self
-                .emit(
-                    Event::Approval(
-                        ApprovalEvent { owner: owner, spender: spender, value: amount, }
-                    )
-                );
-
-            true
-        }
-
-        fn transfer(ref self: ContractState, amount: u256, to_: ContractAddress) -> bool {
-            // get sender/caller address
-            let sender: ContractAddress = get_caller_address();
-            let zero_address = contract_address_const::<0x0>();
-
-            // ensure sender is not address zero
-            assert(sender != zero_address, errors::SENDER_ZERO_ADDRESS);
-
-            // ensure to address is not zero address
-            assert(to_ != zero_address, errors::RECIPIENT_ZERO_ADDRESS);
-
-            // get sender's balance using entry()
-            let sender_balance: u256 = self.balances.entry(sender).read();
-
-            // ensure sender's balance is >= amount
-            assert(sender_balance >= amount, errors::INSUFFICIENT_BALANCE);
-
-            // remove amount from sender using entry()
-            self.balances.entry(sender).write(sender_balance - amount);
-
-            // get the current balance of to_address using entry()
-            let to_current_balance = self.balances.entry(to_).read();
-
-            // transfer amount to to_address using entry()
-            self.balances.entry(to_).write(to_current_balance + amount);
-
-            self.emit(Event::Transfer(TransferEvent { from: sender, to: to_, value: amount, }));
-
-            true
-        }
-
-        fn transfer_from(
-            ref self: ContractState, from_: ContractAddress, to_: ContractAddress, amount: u256
-        ) -> bool {
-            let caller: ContractAddress = get_caller_address();
-            let zero_address = contract_address_const::<0x0>();
-
-            assert(caller != zero_address, errors::CALLER_ZERO_ADDRESS);
-
-            // Using entry() for compound key Map
-            let allowance = self.allowances.entry((from_, caller)).read();
-            assert(allowance >= amount, errors::INSUFFICIENT_ALLOWANCE);
-
-            let from_balance = self.balances.entry(from_).read();
-            assert(from_balance >= amount, errors::INSUFFICIENT_BALANCE);
-
-            // Update allowance using entry()
-            self.allowances.entry((from_, caller)).write(allowance - amount);
-
-            // Update balances using entry()
-            self.balances.entry(from_).write(from_balance - amount);
-            let to_balance = self.balances.entry(to_).read();
-            self.balances.entry(to_).write(to_balance + amount);
-
-            self.emit(Event::Transfer(TransferEvent { from: from_, to: to_, value: amount }));
-
-            true
-        }
-
-
-        fn allowance(
-            self: @ContractState, owner: ContractAddress, spender: ContractAddress
-        ) -> u256 {
-            self.allowances.entry((owner, spender)).read()
-        }
-
-        fn mint(ref self: ContractState, to_: ContractAddress, amount: u256) {
-            //get caller
-            let caller: ContractAddress = get_caller_address();
-
-            let zero_address = contract_address_const::<0x0>();
-            //get owner
-            let owner: ContractAddress = self.owner.read();
-
-            //ensure to_ is not address zero
-            assert(to_ != zero_address, errors::RECIPIENT_ZERO_ADDRESS);
-            //ensure caller is not address zero
-            assert(caller != zero_address, errors::CALLER_ZERO_ADDRESS);
-
-            //ensure caller is the owner
-            assert(caller == owner, errors::CALLER_NOT_OWNER);
-
-            //get current ballance
-            let to_current_balance = self.balances.entry(to_).read();
-            //increase to_ balance with amount
-            self.balances.entry(to_).write(to_current_balance + amount);
-
-            //get the current total supply
-            let current_supply = self.totalSupply.read();
-            //increase total supply with amount
-            self.totalSupply.write(current_supply + amount);
-
-            self.emit(Event::Mint(MintEvent { to: to_, value: amount, }));
-        }
-
-        fn burn(ref self: ContractState, amount: u256) {
-            //get caller
-            let caller: ContractAddress = get_caller_address();
-
-            let zero_address = contract_address_const::<0x0>();
-            //get owner
-            let owner: ContractAddress = self.owner.read();
-
-            //ensure caller is not address zero
-            assert(caller != zero_address, errors::CALLER_ZERO_ADDRESS);
-
-            //ensure caller is the owner
-            assert(caller == owner, errors::CALLER_NOT_OWNER);
-
-            //get callers current balance
-            let caller_balance = self.balances.entry(caller).read();
-            //reduce callers balance with amount
-            self.balances.entry(caller).write(caller_balance - amount);
-
-            //get the current total supply
-            let current_supply = self.totalSupply.read();
-            //substract amount from current total supply
-            self.totalSupply.write(current_supply - amount);
-
-            self.emit(Event::Burn(BurnEvent { from: caller, value: amount, }));
+    impl MintableImpl of IMintable<ContractState> {
+        fn mint(ref self: ContractState, recipient: ContractAddress, amount: u256) {
+            self.ownable.assert_only_owner();
+            self.erc20.mint(recipient, amount);
+            self.emit(MintEvent { recipient, amount });
         }
     }
 
-    #[generate_trait]
-    impl internalImpl of internalTrait {
-        fn zero_address() -> ContractAddress {
-            contract_address_const::<0x0>()
+    #[abi(embed_v0)]
+    impl BurnableImpl of IBurnable<ContractState> {
+        fn burn(ref self: ContractState, amount: u256) {
+            let burner = get_caller_address();
+            self.ownable.assert_only_owner();
+            self.erc20.burn(burner, amount);
+            self.emit(BurnEvent { from: burner, amount });
+        }
+    }
+    //
+    // Upgradeable
+    //
+
+    #[abi(embed_v0)]
+    impl UpgradeableImpl of IUpgradeable<ContractState> {
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            self.ownable.assert_only_owner();
+            self.upgradeable.upgrade(new_class_hash);
         }
     }
 }

--- a/contract_/tests/test_token_contract.cairo
+++ b/contract_/tests/test_token_contract.cairo
@@ -1,3 +1,427 @@
-use starknet::{ContractAddress, get_caller_address};
-use snforge_std::{declare, ContractClassTrait, DeclareResult};
-use contract_::erc20::{Ierc20Dispatcher, Ierc20DispatcherTrait};
+use contract_::erc20::{
+    IBurnableDispatcher, IBurnableDispatcherTrait, IMintableDispatcher, IMintableDispatcherTrait,
+    MusicStrk,
+};
+use openzeppelin::token::erc20::erc20::ERC20Component;
+use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
+use openzeppelin::utils::serde::SerializedAppend;
+use snforge_std::{
+    CheatSpan, ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait,
+    cheat_caller_address, declare, spy_events,
+};
+use starknet::{ContractAddress, contract_address_const};
+
+
+fn owner() -> ContractAddress {
+    contract_address_const::<'owner'>()
+}
+
+fn zero() -> ContractAddress {
+    contract_address_const::<0>()
+}
+
+fn kim() -> ContractAddress {
+    contract_address_const::<'kim'>()
+}
+
+fn thurston() -> ContractAddress {
+    contract_address_const::<'thurston'>()
+}
+
+fn lee() -> ContractAddress {
+    contract_address_const::<'lee'>()
+}
+
+fn mint(contract_address: ContractAddress, recipient: ContractAddress, amount: u256) {
+    cheat_caller_address(contract_address, owner(), CheatSpan::TargetCalls(1));
+    IMintableDispatcher { contract_address }.mint(recipient, amount);
+}
+
+fn deploy_erc20() -> ContractAddress {
+    let owner = owner();
+    let contract_class = declare("MusicStrk").unwrap().contract_class();
+    let mut calldata = array![];
+    calldata.append_serde(owner);
+    let (contract_address, _) = contract_class.deploy(@calldata).unwrap();
+    contract_address
+}
+
+#[test]
+fn test_owner_can_mint() {
+    let owner = owner();
+    let kim = kim();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    let erc20 = IERC20Dispatcher { contract_address };
+    let previous_balance = erc20.balance_of(owner);
+    cheat_caller_address(contract_address, owner, CheatSpan::TargetCalls(1));
+    IMintableDispatcher { contract_address }.mint(owner, amount);
+    let balance = erc20.balance_of(owner);
+    assert(balance - previous_balance == amount, 'Wrong amount after mint');
+
+    let previous_balance = erc20.balance_of(kim);
+    cheat_caller_address(contract_address, owner, CheatSpan::TargetCalls(1));
+    IMintableDispatcher { contract_address }.mint(kim, amount);
+    let balance = erc20.balance_of(kim);
+    assert(balance - previous_balance == amount, 'Wrong amount after mint');
+}
+
+#[test]
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_only_owner_can_mint() {
+    let kim = kim();
+    let contract_address = deploy_erc20();
+
+    cheat_caller_address(contract_address, kim, CheatSpan::TargetCalls(1));
+    IMintableDispatcher { contract_address }.mint(kim, 1000);
+}
+
+#[test]
+fn test_supply_is_updated_after_mint() {
+    let kim = kim();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    let erc20 = IERC20Dispatcher { contract_address };
+    let previous_supply = erc20.total_supply();
+    mint(contract_address, kim, amount);
+    let supply = erc20.total_supply();
+    assert(supply - previous_supply == amount, 'Wrong supply after mint');
+}
+
+#[test]
+fn test_mint_emit_event() {
+    let owner = owner();
+    let kim = kim();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    let mut spy = spy_events();
+
+    cheat_caller_address(contract_address, owner, CheatSpan::TargetCalls(1));
+    IMintableDispatcher { contract_address }.mint(kim, amount);
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    MusicStrk::Event::MintEvent(MusicStrk::MintEvent { recipient: kim, amount }),
+                ),
+            ],
+        );
+}
+
+#[test]
+#[should_panic(expected: 'ERC20: mint to 0')]
+fn test_mint_recipient_is_zero() {
+    let owner = owner();
+    let zero = zero();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+
+    cheat_caller_address(contract_address, owner, CheatSpan::TargetCalls(1));
+    IMintableDispatcher { contract_address }.mint(zero, amount);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_only_owner_can_burn() {
+    let kim = kim();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    mint(contract_address, kim, amount);
+    cheat_caller_address(contract_address, kim, CheatSpan::TargetCalls(1));
+    IBurnableDispatcher { contract_address }.burn(amount);
+}
+
+
+#[test]
+fn test_supply_is_updated_after_burn() {
+    let owner = owner();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    let erc20 = IERC20Dispatcher { contract_address };
+    mint(contract_address, owner, amount);
+
+    let previous_supply = erc20.total_supply();
+    cheat_caller_address(contract_address, owner, CheatSpan::TargetCalls(1));
+    IBurnableDispatcher { contract_address }.burn(amount);
+    let supply = erc20.total_supply();
+    assert(previous_supply - supply == amount, 'Wrong supply after burn');
+}
+
+#[test]
+fn test_burn_emit_event() {
+    let owner = owner();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    mint(contract_address, owner, amount);
+    let mut spy = spy_events();
+    cheat_caller_address(contract_address, owner, CheatSpan::TargetCalls(1));
+    IBurnableDispatcher { contract_address }.burn(amount);
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    MusicStrk::Event::BurnEvent(MusicStrk::BurnEvent { from: owner, amount }),
+                ),
+            ],
+        );
+}
+
+#[test]
+#[should_panic(expected: 'ERC20: insufficient balance')]
+fn test_cant_burn_more_than_balance() {
+    let owner = owner();
+    let contract_address = deploy_erc20();
+    mint(contract_address, owner, 1000);
+    let erc20 = IERC20Dispatcher { contract_address };
+    let balance = erc20.balance_of(owner);
+    cheat_caller_address(contract_address, owner, CheatSpan::TargetCalls(1));
+    IBurnableDispatcher { contract_address }.burn(balance + 1);
+}
+
+#[test]
+fn test_transfer() {
+    let kim = kim();
+    let thurston = thurston();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    mint(contract_address, kim, amount);
+    let erc20 = IERC20Dispatcher { contract_address };
+    let previous_balance_kim = erc20.balance_of(kim);
+    let previous_balance_thurston = erc20.balance_of(thurston);
+    cheat_caller_address(contract_address, kim, CheatSpan::TargetCalls(1));
+    erc20.transfer(thurston, amount);
+    let balance_kim = erc20.balance_of(kim);
+    let balance_thurston = erc20.balance_of(thurston);
+    assert(previous_balance_kim - balance_kim == amount, 'Wrong amount after transfer');
+    assert(balance_thurston - previous_balance_thurston == amount, 'Wrong amount after transfer');
+}
+
+
+#[test]
+fn test_transfer_emit_event() {
+    let kim = kim();
+    let thurston = thurston();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    mint(contract_address, thurston, amount);
+
+    let erc20 = IERC20Dispatcher { contract_address };
+    let mut spy = spy_events();
+    cheat_caller_address(contract_address, thurston, CheatSpan::TargetCalls(1));
+    erc20.transfer(kim, amount);
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    ERC20Component::Event::Transfer(
+                        ERC20Component::Transfer { from: thurston, to: kim, value: amount },
+                    ),
+                ),
+            ],
+        );
+}
+
+#[test]
+#[should_panic(expected: 'ERC20: insufficient balance')]
+fn test_transfer_not_enough_balance() {
+    let kim = kim();
+    let thurston = thurston();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    mint(contract_address, thurston, amount);
+
+    let erc20 = IERC20Dispatcher { contract_address };
+    let balance = erc20.balance_of(thurston);
+    cheat_caller_address(contract_address, thurston, CheatSpan::TargetCalls(1));
+    erc20.transfer(kim, balance + 1);
+}
+
+#[test]
+#[should_panic(expected: 'ERC20: transfer to 0')]
+fn test_transfer_to_zero_address() {
+    let zero = zero();
+    let thurston = thurston();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    mint(contract_address, thurston, amount);
+
+    let erc20 = IERC20Dispatcher { contract_address };
+    let balance = erc20.balance_of(thurston);
+    cheat_caller_address(contract_address, thurston, CheatSpan::TargetCalls(1));
+    erc20.transfer(zero, balance);
+}
+
+#[test]
+fn test_transfer_from() {
+    let kim = kim();
+    let thurston = thurston();
+    let lee = lee();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    mint(contract_address, kim, 2 * amount);
+
+    let erc20 = IERC20Dispatcher { contract_address };
+    let previous_balance_kim = erc20.balance_of(kim);
+    let previous_balance_thurston = erc20.balance_of(thurston);
+
+    cheat_caller_address(contract_address, kim, CheatSpan::TargetCalls(1));
+    erc20.approve(lee, amount);
+
+    cheat_caller_address(contract_address, lee, CheatSpan::TargetCalls(1));
+    erc20.transfer_from(kim, thurston, amount);
+
+    let balance_kim = erc20.balance_of(kim);
+    let balance_thurston = erc20.balance_of(thurston);
+    assert(previous_balance_kim - balance_kim == amount, 'Wrong amount after transfer');
+    assert(balance_thurston - previous_balance_thurston == amount, 'Wrong amount after transfer');
+}
+
+#[test]
+fn test_transfer_from_emit_event() {
+    let kim = kim();
+    let thurston = thurston();
+    let lee = lee();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    mint(contract_address, kim, 2 * amount);
+
+    let erc20 = IERC20Dispatcher { contract_address };
+    cheat_caller_address(contract_address, kim, CheatSpan::TargetCalls(1));
+    erc20.approve(lee, amount);
+
+    let mut spy = spy_events();
+    cheat_caller_address(contract_address, lee, CheatSpan::TargetCalls(1));
+    erc20.transfer_from(kim, thurston, amount);
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    ERC20Component::Event::Transfer(
+                        ERC20Component::Transfer { from: kim, to: thurston, value: amount },
+                    ),
+                ),
+            ],
+        );
+}
+
+#[test]
+#[should_panic(expected: 'ERC20: insufficient allowance')]
+fn test_transfer_from_not_enough_allowance() {
+    let kim = kim();
+    let thurston = thurston();
+    let lee = lee();
+    let amount = 1000;
+    let allowed_amount = amount - 1;
+    let contract_address = deploy_erc20();
+    mint(contract_address, kim, amount);
+
+    let erc20 = IERC20Dispatcher { contract_address };
+    cheat_caller_address(contract_address, kim, CheatSpan::TargetCalls(1));
+    erc20.approve(lee, allowed_amount);
+
+    cheat_caller_address(contract_address, lee, CheatSpan::TargetCalls(1));
+    erc20.transfer_from(kim, thurston, amount);
+}
+
+#[test]
+#[should_panic(expected: 'ERC20: insufficient balance')]
+fn test_transfer_from_not_enough_balance() {
+    let kim = kim();
+    let thurston = thurston();
+    let lee = lee();
+    let amount = 1000;
+    let transfer_amount = amount + 1;
+    let contract_address = deploy_erc20();
+    mint(contract_address, kim, amount);
+
+    let erc20 = IERC20Dispatcher { contract_address };
+    cheat_caller_address(contract_address, kim, CheatSpan::TargetCalls(1));
+    erc20.approve(lee, transfer_amount);
+
+    cheat_caller_address(contract_address, lee, CheatSpan::TargetCalls(1));
+    erc20.transfer_from(kim, thurston, transfer_amount);
+}
+
+#[test]
+#[should_panic(expected: 'ERC20: transfer to 0')]
+fn test_transfrom_from_to_zero_address() {
+    let kim = kim();
+    let zero = zero();
+    let lee = lee();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    mint(contract_address, kim, 2 * amount);
+
+    let erc20 = IERC20Dispatcher { contract_address };
+
+    cheat_caller_address(contract_address, kim, CheatSpan::TargetCalls(1));
+    erc20.approve(lee, amount);
+
+    cheat_caller_address(contract_address, lee, CheatSpan::TargetCalls(1));
+    erc20.transfer_from(kim, zero, amount);
+}
+
+#[test]
+fn test_allowance() {
+    let kim = kim();
+    let lee = lee();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    let erc20 = IERC20Dispatcher { contract_address };
+    let allowance = erc20.allowance(kim, lee);
+    assert(allowance == 0, 'Wrong allowance');
+    cheat_caller_address(contract_address, kim, CheatSpan::TargetCalls(1));
+    erc20.approve(lee, amount);
+    let allowance = erc20.allowance(kim, lee);
+    assert(allowance == amount, 'Wrong allowance');
+}
+
+#[test]
+fn test_allowance_is_updated_after_transfer_from() {
+    let kim = kim();
+    let thurston = thurston();
+    let lee = lee();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    mint(contract_address, kim, 2 * amount);
+
+    let erc20 = IERC20Dispatcher { contract_address };
+
+    cheat_caller_address(contract_address, kim, CheatSpan::TargetCalls(1));
+    erc20.approve(lee, amount);
+    let previous_allowance = erc20.allowance(kim, lee);
+
+    cheat_caller_address(contract_address, lee, CheatSpan::TargetCalls(1));
+    erc20.transfer_from(kim, thurston, amount);
+
+    let allowance = erc20.allowance(kim, lee);
+
+    assert(previous_allowance - allowance == amount, 'Wrong allowance after transfer');
+}
+
+#[test]
+fn test_approve_emit_event() {
+    let kim = kim();
+    let lee = lee();
+    let amount = 1000;
+    let contract_address = deploy_erc20();
+    let erc20 = IERC20Dispatcher { contract_address };
+    let mut spy = spy_events();
+    cheat_caller_address(contract_address, kim, CheatSpan::TargetCalls(1));
+    erc20.approve(lee, amount);
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    ERC20Component::Event::Approval(
+                        ERC20Component::Approval { owner: kim, spender: lee, value: amount },
+                    ),
+                ),
+            ],
+        );
+}


### PR DESCRIPTION
This PR introduce the following changes:
- ERC20 contract is now using OpenZeppelin 1.0.0 components
- scarb updated to 2.9.4 (OpenZeppelin dependency)
- Add tests using starknet-foundry
- Add CI worflow to check formatting and run test when modifications are present in `contract_` folder

The following tests are implemented:
#### Mint
- Only owner can mint
- Can't mint to zero address
- Total supply is updated after mint
- Mint event is emitted

#### Burn
- Only owner can burn
- Total supply is updated after burn
- Can't burn more than current balance
- Burn event is emitted

#### Transfer
- Balances are updated after transfer
- Transfer event is emitted
- Can't transfer more than current balance
- Can't transfer to zero address

#### Transfer From
- Balances are updated after transfer from
- Transfer event is emitted
- Can't transfer from more than allowance
- Can't transfer from more than current balance
- Can't transfer from to zero address

#### Approve/Allowance
 - Approve correctly set allowance
 - Allowance is updated after transfer from
 - Approval event is emitted

Close #4