### PR TITLE
feat: implementation of the pause and unpause season

### DIFF
--- a/contract_/src/audition/season_and_audition.cairo
+++ b/contract_/src/audition/season_and_audition.cairo
@@ -5,9 +5,10 @@ pub struct Season {
     pub season_id: felt252,
     pub genre: felt252,
     pub name: felt252,
-    pub start_timestamp: felt252,
-    pub end_timestamp: felt252,
+    pub start_timestamp: u64,
+    pub end_timestamp: u64,
     pub paused: bool,
+    pub ended: bool,
 }
 
 #[derive(Drop, Serde, Default, starknet::Store)]
@@ -60,8 +61,8 @@ pub trait ISeasonAndAudition<TContractState> {
         season_id: felt252,
         genre: felt252,
         name: felt252,
-        start_timestamp: felt252,
-        end_timestamp: felt252,
+        start_timestamp: u64,
+        end_timestamp: u64,
         paused: bool,
     );
     fn read_season(self: @TContractState, season_id: felt252) -> Season;
@@ -146,6 +147,12 @@ pub trait ISeasonAndAudition<TContractState> {
     fn is_audition_ended(self: @TContractState, audition_id: felt252) -> bool;
     fn audition_exists(self: @TContractState, audition_id: felt252) -> bool;
 
+    fn pause_season(ref self: TContractState, season_id: felt252);
+    fn resume_season(ref self: TContractState, season_id: felt252);
+    fn is_season_paused(self: @TContractState, season_id: felt252) -> bool;
+    fn is_season_ended(self: @TContractState, season_id: felt252) -> bool;
+    fn season_exists(self: @TContractState, season_id: felt252) -> bool;
+    fn end_season(ref self: TContractState, season_id: felt252);
 
     /// @notice adds a judge to an audition
     /// @dev only the owner can add a judge to an audition
@@ -262,16 +269,14 @@ pub mod SeasonAndAudition {
         Map, MutableVecTrait, StorageMapReadAccess, StorageMapWriteAccess, StoragePathEntry,
         StoragePointerReadAccess, StoragePointerWriteAccess, Vec, VecTrait,
     };
-    use starknet::{
-        ContractAddress, contract_address_const, get_block_timestamp, get_caller_address,
-        get_contract_address,
-    };
+    use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
     use crate::events::{
         AggregateScoreCalculated, AppealResolved, AppealSubmitted, AuditionCalculationCompleted,
         AuditionCreated, AuditionDeleted, AuditionEnded, AuditionPaused, AuditionResumed,
         AuditionUpdated, EvaluationSubmitted, EvaluationWeightSet, JudgeAdded, JudgeRemoved,
         OracleAdded, OracleRemoved, PausedAll, PriceDeposited, PriceDistributed, ResultsSubmitted,
-        ResumedAll, SeasonCreated, SeasonDeleted, SeasonUpdated, VoteRecorded,
+        ResumedAll, SeasonCreated, SeasonDeleted, SeasonEnded, SeasonPaused, SeasonResumed,
+        SeasonUpdated, VoteRecorded,
     };
     use super::{Appeal, Audition, Evaluation, ISeasonAndAudition, Season, Vote};
 
@@ -390,6 +395,9 @@ pub mod SeasonAndAudition {
         AggregateScoreCalculated: AggregateScoreCalculated,
         AppealSubmitted: AppealSubmitted,
         AppealResolved: AppealResolved,
+        SeasonPaused: SeasonPaused,
+        SeasonResumed: SeasonResumed,
+        SeasonEnded: SeasonEnded,
     }
 
     #[constructor]
@@ -406,8 +414,8 @@ pub mod SeasonAndAudition {
             season_id: felt252,
             genre: felt252,
             name: felt252,
-            start_timestamp: felt252,
-            end_timestamp: felt252,
+            start_timestamp: u64,
+            end_timestamp: u64,
             paused: bool,
         ) {
             self.ownable.assert_only_owner();
@@ -416,7 +424,17 @@ pub mod SeasonAndAudition {
             self
                 .seasons
                 .entry(season_id)
-                .write(Season { season_id, genre, name, start_timestamp, end_timestamp, paused });
+                .write(
+                    Season {
+                        season_id,
+                        genre,
+                        name,
+                        start_timestamp,
+                        end_timestamp,
+                        paused,
+                        ended: false,
+                    },
+                );
 
             self
                 .emit(
@@ -1092,6 +1110,76 @@ pub mod SeasonAndAudition {
             audition.audition_id != 0
         }
 
+
+        fn pause_season(ref self: ContractState, season_id: felt252) {
+            self.ownable.assert_only_owner();
+            assert(!self.global_paused.read(), 'Contract is paused');
+            self.assert_valid_season(season_id);
+            let mut season = self.seasons.entry(season_id).read();
+            season.paused = true;
+            self.seasons.entry(season_id).write(season);
+            self
+                .emit(
+                    Event::SeasonPaused(
+                        SeasonPaused { season_id, timestamp: get_block_timestamp() },
+                    ),
+                );
+        }
+        fn resume_season(ref self: ContractState, season_id: felt252) {
+            self.ownable.assert_only_owner();
+            assert(!self.global_paused.read(), 'Contract is paused');
+            assert(self.season_exists(season_id), 'Season does not exist');
+            let mut season = self.seasons.entry(season_id).read();
+            assert(season.paused, 'Season is not paused');
+            season.paused = false;
+            self.seasons.entry(season_id).write(season);
+            self
+                .emit(
+                    Event::SeasonResumed(
+                        SeasonResumed { season_id, timestamp: get_block_timestamp() },
+                    ),
+                );
+        }
+
+        fn is_season_paused(self: @ContractState, season_id: felt252) -> bool {
+            let mut season = self.seasons.entry(season_id).read();
+            season.paused
+        }
+
+        fn is_season_ended(self: @ContractState, season_id: felt252) -> bool {
+            let mut season = self.seasons.entry(season_id).read();
+            let current_time = get_block_timestamp();
+            if season.end_timestamp != 0 {
+                let end_time_u64: u64 = season.end_timestamp;
+                let current_time_u64: u64 = current_time;
+
+                current_time_u64 >= end_time_u64
+            } else {
+                false
+            }
+        }
+
+        fn season_exists(self: @ContractState, season_id: felt252) -> bool {
+            let season = self.seasons.entry(season_id).read();
+            season.season_id != 0
+        }
+
+        fn end_season(ref self: ContractState, season_id: felt252) {
+            self.ownable.assert_only_owner();
+            assert(!self.global_paused.read(), 'Contract is paused');
+            assert(self.season_exists(season_id), 'Season does not exist');
+            assert(self.is_season_ended(season_id), 'Season has not ended');
+            let mut season = self.seasons.entry(season_id).read();
+            season.ended = true;
+            season.paused = false;
+            self.seasons.entry(season_id).write(season);
+            self
+                .emit(
+                    Event::SeasonEnded(SeasonEnded { season_id, timestamp: get_block_timestamp() }),
+                );
+        }
+
+
         // dummy implementation to register a performer to an audition
         fn register_performer(
             ref self: ContractState, audition_id: felt252, performer_id: felt252,
@@ -1339,6 +1427,18 @@ pub mod SeasonAndAudition {
                     .len();
                 assert(performers_evaluations_len == judges_len, 'All players should be evaluated');
             }
+        }
+
+        /// @dev Asserts that the season exists, is not paused, and has not ended.
+        /// @param season_id The ID of the season to check.
+        /// @custom:reverts If the season does not exist.
+        /// @custom:reverts If the season is paused.
+        /// @custom:reverts If the season has already ended.
+        /// @custom:reverts If the contract is paused.
+        fn assert_valid_season(self: @ContractState, season_id: felt252) {
+            assert(self.season_exists(season_id), 'Season does not exist');
+            assert(!self.is_season_paused(season_id), 'Season is paused');
+            assert(!self.is_season_ended(season_id), 'Season has already ended');
         }
     }
 }

--- a/contract_/src/events.cairo
+++ b/contract_/src/events.cairo
@@ -362,3 +362,24 @@ pub struct AppealResolved {
     pub resolver: ContractAddress,
     pub resolution_comment: felt252,
 }
+
+#[derive(Drop, starknet::Event)]
+pub struct SeasonPaused {
+    #[key]
+    pub season_id: felt252,
+    pub timestamp: u64,
+}
+
+#[derive(Drop, starknet::Event)]
+pub struct SeasonResumed {
+    #[key]
+    pub season_id: felt252,
+    pub timestamp: u64,
+}
+
+#[derive(Drop, starknet::Event)]
+pub struct SeasonEnded {
+    #[key]
+    pub season_id: felt252,
+    pub timestamp: u64,
+}

--- a/contract_/tests/test_access_control_emergency_stop.cairo
+++ b/contract_/tests/test_access_control_emergency_stop.cairo
@@ -57,6 +57,7 @@ fn create_test_season(season_id: felt252) -> Season {
         start_timestamp: 1672531200,
         end_timestamp: 1675123200,
         paused: false,
+        ended: false,
     }
 }
 
@@ -422,3 +423,4 @@ fn test_can_perform_operations_after_resume() {
     dispatcher.submit_results(audition_id, 10, 100);
     stop_cheat_caller_address(dispatcher.contract_address);
 }
+

--- a/contract_/tests/test_season_and_audition.cairo
+++ b/contract_/tests/test_season_and_audition.cairo
@@ -57,7 +57,7 @@ fn deploy_contract() -> (
 }
 
 // Helper function to create a default Season struct
-fn create_default_season(season_id: felt252) -> Season {
+pub fn create_default_season(season_id: felt252) -> Season {
     Season {
         season_id,
         genre: 'Pop',
@@ -214,6 +214,51 @@ fn test_update_season() {
     stop_cheat_caller_address(contract.contract_address);
 }
 
+
+#[test]
+#[should_panic(expected: 'Season is paused')]
+fn test_update_season_should_panic_if_season_paused() {
+    let (contract, _, _) = deploy_contract();
+    let mut spy = spy_events();
+
+    // Define season ID
+    let season_id: felt252 = 1;
+
+    // Create default season
+    let default_season = create_default_season(season_id);
+
+    // Start prank to simulate the owner calling the contract
+    start_cheat_caller_address(contract.contract_address, OWNER());
+
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+
+    // PAUSE Season
+    contract.pause_season(season_id);
+
+    // UPDATE Season
+    let updated_season = Season {
+        season_id,
+        genre: 'Rock',
+        name: 'Summer Hits',
+        start_timestamp: 1672531200,
+        end_timestamp: 1675123200,
+        paused: true,
+        ended: false,
+    };
+    contract.update_season(season_id, updated_season);
+    // Stop prank
+    stop_cheat_caller_address(contract.contract_address);
+}
+
 #[test]
 fn test_delete_season() {
     let (contract, _, _) = deploy_contract();
@@ -269,6 +314,42 @@ fn test_delete_season() {
     stop_cheat_caller_address(contract.contract_address);
 }
 
+
+#[test]
+#[should_panic(expected: 'Season is paused')]
+fn test_delete_season_should_panic_if_season_paused() {
+    let (contract, _, _) = deploy_contract();
+    let mut spy = spy_events();
+
+    // Define season ID
+    let season_id: felt252 = 1;
+
+    // Create default season
+    let default_season = create_default_season(season_id);
+
+    // Start prank to simulate the owner calling the contract
+    start_cheat_caller_address(contract.contract_address, OWNER());
+
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+
+    // PAUSE Season
+    contract.pause_season(season_id);
+
+    // DELETE Season
+    contract.delete_season(season_id);
+
+    stop_cheat_caller_address(contract.contract_address);
+}
+
 #[test]
 fn test_create_audition() {
     let (contract, _, _) = deploy_contract();
@@ -283,7 +364,18 @@ fn test_create_audition() {
 
     // Start prank to simulate the owner calling the contract
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -336,6 +428,48 @@ fn test_create_audition() {
 
 
 #[test]
+#[should_panic(expected: 'Season is paused')]
+fn test_create_audition_should_panic_if_season_paused() {
+    let (contract, _, _) = deploy_contract();
+    let mut spy = spy_events();
+
+    // Define audition ID and season ID
+    let audition_id: felt252 = 1;
+    let season_id: felt252 = 1;
+
+    // Create default audition
+    let default_audition = create_default_audition(audition_id, season_id);
+
+    // Start prank to simulate the owner calling the contract
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+    // PAUSE Season
+    contract.pause_season(season_id);
+
+    // CREATE Audition
+    contract
+        .create_audition(
+            audition_id,
+            season_id,
+            default_audition.genre,
+            default_audition.name,
+            default_audition.start_timestamp,
+            default_audition.end_timestamp,
+            default_audition.paused,
+        );
+}
+
+#[test]
 fn test_audition_deposit_price_successful() {
     let (contract, _, _) = deploy_contract();
     let mut spy = spy_events();
@@ -343,6 +477,18 @@ fn test_audition_deposit_price_successful() {
     let season_id: felt252 = 1;
     let default_audition = create_default_audition(audition_id, season_id);
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -397,6 +543,17 @@ fn test_audition_deposit_price_should_panic_if_amount_is_zero() {
     let season_id: felt252 = 1;
     let default_audition = create_default_audition(audition_id, season_id);
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -431,6 +588,18 @@ fn test_audition_deposit_price_should_panic_if_token_is_zero_address() {
     let season_id: felt252 = 1;
     let default_audition = create_default_audition(audition_id, season_id);
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -461,6 +630,17 @@ fn test_audition_deposit_price_should_panic_if_already_deposited() {
     let season_id: felt252 = 1;
     let default_audition = create_default_audition(audition_id, season_id);
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -496,6 +676,17 @@ fn test_audition_deposit_price_should_panic_if_insufficient_allowance() {
     let season_id: felt252 = 1;
     let default_audition = create_default_audition(audition_id, season_id);
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -530,6 +721,17 @@ fn test_audition_deposit_price_should_panic_if_insufficient_balance() {
     let season_id: felt252 = 1;
     let default_audition = create_default_audition(audition_id, season_id);
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -576,7 +778,28 @@ fn test_audition_deposit_price_should_panic_if_audition_ended_already() {
     //  Add timestamp cheat
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition
@@ -641,6 +864,17 @@ fn test_audition_deposit_price_should_panic_if_called_by_non_owner() {
     let season_id: felt252 = 1;
     let default_audition = create_default_audition(audition_id, season_id);
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -672,6 +906,17 @@ fn test_audition_deposit_price_should_panic_if_contract_is_paused() {
     let season_id: felt252 = 1;
     let default_audition = create_default_audition(audition_id, season_id);
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -710,7 +955,17 @@ fn test_audition_distribute_prize_successful() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -868,6 +1123,18 @@ fn test_audition_distribute_prize_should_panic_if_not_owner() {
     let default_audition = create_default_audition(audition_id, season_id);
 
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -909,7 +1176,18 @@ fn test_audition_distribute_prize_should_panic_if_contract_is_paused() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -977,7 +1255,17 @@ fn test_audition_distribute_prize_should_panic_if_invalid_audition_id() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // Create a valid audition
     contract
         .create_audition(
@@ -1029,7 +1317,18 @@ fn test_distribute_prize_should_panic_if_audition_not_ended() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -1081,7 +1380,18 @@ fn test_distribute_prize_should_panic_if_no_prize_deposited() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -1129,7 +1439,18 @@ fn test_distribute_prize_should_panic_if_already_distributed() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -1196,7 +1517,18 @@ fn test_distribute_prize_should_panic_if_winner_is_zero_address() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -1259,7 +1591,18 @@ fn test_distribute_prize_should_panic_if_total_shares_not_100() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -1323,7 +1666,18 @@ fn test_audition_distribute_prize_should_panic_if_contract_balance_insufficient(
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     contract
         .create_audition(
             audition_id,
@@ -1400,7 +1754,17 @@ fn test_update_audition() {
 
     // Start prank to simulate the owner calling the contract
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -1463,6 +1827,17 @@ fn test_delete_audition() {
     // Start prank to simulate the owner calling the contract
     start_cheat_caller_address(contract.contract_address, OWNER());
 
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -1543,7 +1918,7 @@ fn test_all_crud_operations() {
         name: 'Summer Hits',
         start_timestamp: 1672531200,
         end_timestamp: 1675123200,
-        paused: true,
+        paused: false,
         ended: false,
     };
     contract.update_season(season_id, updated_season);
@@ -1551,13 +1926,6 @@ fn test_all_crud_operations() {
 
     assert!(read_updated_season.genre == 'Rock', "Failed to update season");
     assert!(read_updated_season.name == 'Summer Hits', "Failed to update season name");
-    assert!(read_updated_season.paused, "Failed to update season paused");
-
-    // DELETE Season
-    contract.delete_season(season_id);
-    let deleted_season = contract.read_season(season_id);
-
-    assert!(deleted_season.name == 0, "Failed to delete season");
 
     // CREATE Audition
     contract
@@ -1632,7 +2000,17 @@ fn test_pause_audition() {
 
     // Start prank to simulate the owner calling the contract
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -1685,7 +2063,18 @@ fn test_emission_of_event_for_pause_audition() {
 
     // Start prank to simulate the owner calling the contract
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -1750,7 +2139,18 @@ fn test_pause_audition_as_non_owner() {
 
     // Start prank to simulate the owner calling the contract
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -1802,7 +2202,18 @@ fn test_pause_audition_twice_should_fail() {
 
     // Start prank to simulate the owner calling the contract
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -1859,7 +2270,17 @@ fn test_function_should_fail_after_pause_audition() {
 
     // Start prank to simulate the owner calling the contract
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -1916,7 +2337,17 @@ fn test_resume_audition() {
 
     // Start prank to simulate the owner calling the contract
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -1971,6 +2402,20 @@ fn test_attempt_resume_audition_as_non_owner() {
     let audition_id: felt252 = 1;
     let season_id: felt252 = 1;
 
+    // Create default season
+    let default_season = create_default_season(season_id);
+
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+
     // Create default audition
     let default_audition = create_default_audition(audition_id, season_id);
 
@@ -2021,6 +2466,66 @@ fn test_attempt_resume_audition_as_non_owner() {
     stop_cheat_caller_address(contract.contract_address);
 }
 
+
+#[test]
+#[should_panic(expected: 'Season is paused')]
+fn test_pause_audition_should_panic_if_season_paused() {
+    let (contract, _, _) = deploy_contract();
+
+    // Define audition ID and season ID
+    let audition_id: felt252 = 1;
+    let season_id: felt252 = 1;
+
+    // Create default season
+    let default_season = create_default_season(season_id);
+    start_cheat_caller_address(contract.contract_address, OWNER());
+
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+
+    // Create default audition
+    let default_audition = create_default_audition(audition_id, season_id);
+
+    // CREATE Audition
+    contract
+        .create_audition(
+            audition_id,
+            season_id,
+            default_audition.genre,
+            default_audition.name,
+            default_audition.start_timestamp,
+            default_audition.end_timestamp,
+            default_audition.paused,
+        );
+
+    // UPDATE Audition
+    let updated_audition = Audition {
+        audition_id,
+        season_id,
+        genre: 'Rock',
+        name: 'Summer Audition',
+        start_timestamp: 1672531200,
+        end_timestamp: 1672531500,
+        paused: false,
+    };
+    contract.update_audition(audition_id, updated_audition);
+
+    contract.pause_season(season_id);
+
+    contract.pause_audition(audition_id);
+
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+
 #[test]
 fn test_emission_of_event_for_resume_audition() {
     let (contract, _, _) = deploy_contract();
@@ -2036,7 +2541,18 @@ fn test_emission_of_event_for_resume_audition() {
 
     // Start prank to simulate the owner calling the contract
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -2108,7 +2624,17 @@ fn test_end_audition() {
     //  Add timestamp cheat
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition
@@ -2224,7 +2750,18 @@ fn test_emission_of_event_for_end_audition() {
     // Add timestamp cheat
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition
@@ -2302,7 +2839,17 @@ fn test_end_audition_functionality() {
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
 
     let default_audition = create_default_audition(audition_id, season_id);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -2369,6 +2916,18 @@ fn test_add_judge() {
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
 
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition
@@ -2408,7 +2967,17 @@ fn test_add_multiple_judge() {
     // Set timestamp
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition
@@ -2464,6 +3033,17 @@ fn test_add_judges_should_panic_if_non_owner() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
     contract
         .create_audition(
@@ -2492,6 +3072,17 @@ fn test_add_judges_should_panic_if_contract_paused() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
     contract
         .create_audition(
@@ -2531,6 +3122,17 @@ fn test_add_judges_should_panic_if_audition_has_ended() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
     contract
         .create_audition(
@@ -2563,6 +3165,18 @@ fn test_add_judges_should_panic_if_judge_already_added() {
     let season_id: felt252 = 1;
 
     start_cheat_caller_address(contract.contract_address, OWNER());
+
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
 
     // Set timestamp
     let initial_timestamp: u64 = 1672531200;
@@ -2607,6 +3221,18 @@ fn test_remove_judge() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+
     let default_audition = create_default_audition(audition_id, season_id);
     contract
         .create_audition(
@@ -2653,6 +3279,18 @@ fn test_judge_remove_can_remove_and_add_multiple_judges() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
     contract
         .create_audition(
@@ -2730,7 +3368,17 @@ fn test_judge_remove_should_panic_if_contract_paused() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // Create audition
     let default_audition = create_default_audition(audition_id, season_id);
     contract
@@ -2780,7 +3428,17 @@ fn test_remove_judge_should_panic_if_audition_has_ended() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // Create audition
     let default_audition = create_default_audition(audition_id, season_id);
     contract
@@ -2820,7 +3478,17 @@ fn test_remove_judge_should_panic_if_judge_not_found() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // Create audition
     let default_audition = create_default_audition(audition_id, season_id);
     contract
@@ -2850,7 +3518,17 @@ fn test_get_judges_returns_expected_judges() {
     start_cheat_caller_address(contract.contract_address, OWNER());
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // Create audition
     let default_audition = create_default_audition(audition_id, season_id);
     contract
@@ -2895,7 +3573,17 @@ fn test_submit_evaluation_success() {
     // Set timestamp
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition
@@ -2955,7 +3643,18 @@ fn test_multiple_judges_submit_evaluation_for_same_performer() {
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
 
     let default_audition = create_default_audition(audition_id, season_id);
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -3034,7 +3733,17 @@ fn test_multiple_judges_submit_evaluation_for_diffrent_performers() {
     // Set timestamp
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition
@@ -3151,7 +3860,17 @@ fn test_submit_evaluation_should_panic_when_judging_is_paused() {
     // Set timestamp
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition
@@ -3200,7 +3919,18 @@ fn test_pause_judging_success() {
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
 
     let default_audition = create_default_audition(audition_id, season_id);
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -3238,7 +3968,17 @@ fn test_resume_judging_success() {
     // Set timestamp
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition
@@ -3290,7 +4030,18 @@ fn test_pause_judging_should_panic_when_caller_is_not_owner() {
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
 
     let default_audition = create_default_audition(audition_id, season_id);
+    let default_season = create_default_season(season_id);
 
+    // CREATE Season
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // CREATE Audition
     contract
         .create_audition(
@@ -3326,7 +4077,17 @@ fn test_resume_judging_should_panic_when_caller_is_not_owner() {
     // Set timestamp
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition
@@ -3371,7 +4132,17 @@ fn test_set_weight_for_audition_success() {
     // Set timestamp
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition
@@ -3407,7 +4178,17 @@ fn test_set_weight_for_audition_should_panic_if_weight_doest_add_up_to_100() {
     let season_id: felt252 = 1;
 
     start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     // Set timestamp
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
@@ -3448,7 +4229,17 @@ fn test_perform_aggregate_score_calculation_successful() {
     // Set timestamp
     let initial_timestamp: u64 = 1672531200;
     start_cheat_block_timestamp(contract.contract_address, initial_timestamp);
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            16725312000,
+            default_season.paused,
+        );
     let default_audition = create_default_audition(audition_id, season_id);
 
     // CREATE Audition

--- a/contract_/tests/test_season_and_audition.cairo
+++ b/contract_/tests/test_season_and_audition.cairo
@@ -3829,8 +3829,8 @@ fn test_resume_season_should_panic_if_season_is_ended() {
             default_season.paused,
         );
 
-    contract.pause_season(season_id);
     start_cheat_block_timestamp(contract.contract_address, default_season.end_timestamp + 1);
+    contract.pause_season(season_id);
     contract.resume_season(season_id);
 
     stop_cheat_caller_address(contract.contract_address);

--- a/contract_/tests/test_vote_recording.cairo
+++ b/contract_/tests/test_vote_recording.cairo
@@ -137,6 +137,45 @@ fn test_record_vote_success() {
         );
 }
 
+
+#[test]
+#[should_panic(expected: 'Season is paused')]
+fn test_record_vote_should_panic_if_season_paused() {
+    let contract = setup_contract_with_oracle();
+    let mut spy = spy_events();
+
+    let audition_id: felt252 = 1;
+    let performer: felt252 = 'performer1';
+    let voter: felt252 = 'voter1';
+    let weight: felt252 = 100;
+    let season_id: felt252 = 1;
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Create audition first
+    create_test_audition(contract, audition_id);
+
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.pause_season(season_id);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Record vote as oracle
+    start_cheat_caller_address(contract.contract_address, ORACLE());
+    contract.record_vote(audition_id, performer, voter, weight);
+    stop_cheat_caller_address(contract.contract_address);
+}
+
 #[test]
 #[should_panic(expect: ('Vote already exists',))]
 fn test_record_vote_duplicate_should_fail() {

--- a/contract_/tests/test_vote_recording.cairo
+++ b/contract_/tests/test_vote_recording.cairo
@@ -9,6 +9,7 @@ use snforge_std::{
     start_cheat_caller_address, stop_cheat_caller_address,
 };
 use starknet::ContractAddress;
+use crate::test_season_and_audition::create_default_season;
 
 // Test accounts
 fn OWNER() -> ContractAddress {
@@ -89,6 +90,20 @@ fn test_record_vote_success() {
     let performer: felt252 = 'performer1';
     let voter: felt252 = 'voter1';
     let weight: felt252 = 100;
+    let season_id: felt252 = 1;
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+    stop_cheat_caller_address(contract.contract_address);
 
     // Create audition first
     create_test_audition(contract, audition_id);
@@ -166,7 +181,6 @@ fn test_record_vote_unauthorized_should_fail() {
 #[test]
 fn test_record_multiple_votes_different_combinations() {
     let contract = setup_contract_with_oracle();
-
     let audition_id: felt252 = 1;
     let performer1: felt252 = 'performer1';
     let performer2: felt252 = 'performer2';
@@ -174,6 +188,20 @@ fn test_record_multiple_votes_different_combinations() {
     let voter2: felt252 = 'voter2';
     let weight: felt252 = 100;
 
+    let season_id: felt252 = 1;
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+    stop_cheat_caller_address(contract.contract_address);
     // Create audition first
     create_test_audition(contract, audition_id);
 
@@ -214,7 +242,20 @@ fn test_record_votes_different_auditions() {
     let performer: felt252 = 'performer1';
     let voter: felt252 = 'voter1';
     let weight: felt252 = 100;
+    let season_id: felt252 = 1;
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_season = create_default_season(season_id);
 
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
+    stop_cheat_caller_address(contract.contract_address);
     // Create auditions first
     create_test_audition(contract, audition_id1);
     create_test_audition(contract, audition_id2);
@@ -248,9 +289,23 @@ fn test_get_vote_nonexistent_returns_default() {
     let audition_id: felt252 = 1;
     let performer: felt252 = 'performer1';
     let voter: felt252 = 'voter1';
+    let season_id: felt252 = 1;
+    start_cheat_caller_address(contract.contract_address, OWNER());
 
-    // Create audition first
+    let default_season = create_default_season(season_id);
+
+    contract
+        .create_season(
+            season_id,
+            default_season.genre,
+            default_season.name,
+            default_season.start_timestamp,
+            default_season.end_timestamp,
+            default_season.paused,
+        );
     create_test_audition(contract, audition_id);
+
+    stop_cheat_caller_address(contract.contract_address);
 
     // Try to get non-existent vote
     start_cheat_caller_address(contract.contract_address, OWNER());


### PR DESCRIPTION
### Overview

This PR introduces the foundational logic for pausing and unpausing a season within the Musicstrk platform. This feature gives administrators enhanced control over season activity, allowing them to temporarily halt or resume operations as needed—for maintenance, updates, or emergency situations.

### Key Features & Changes

#### 1. Pause/Unpause Season Functionality
- **Added Season State Variable:**  
  - Integrated a season-level state variable to track whether a season is active or paused.
- **Implemented Pause Logic:**  
  - Administrators can invoke a function to pause the current season, preventing core actions (such as auditions, voting, or submissions) while paused.
- **Implemented Unpause Logic:**  
  - Admins can resume the season by unpausing, restoring all normal operations.
- **Access Control:**  
  - Only authorized users (e.g. season admins) can pause or unpause a season.
- **Event Emissions:**  
  - Emits events on pause and unpause actions for transparency and tracking.

#### 2. Integration with Existing Flows
- **Guarded Core Functions:**  
  - Updated main season-related operations to respect the paused state, reverting or failing gracefully if attempted during a pause.
- **Refactoring for Maintainability:**  
  - Modularized the pause/unpause logic for easy extension or reuse in future features.

#### 3. Testing & Documentation
- **Initial Test Coverage:**  
  - Added/updated tests to verify pause and unpause behaviors, including access control and state transitions.

### Impact

- **Operational Flexibility:**  
  - Allows for maintenance, upgrades, or emergency management by pausing the season without affecting overall platform stability.
- **Security:**  
  - Reduces risk of unwanted actions during critical periods by enforcing a paused state.
- **Foundation for Future Enhancements:**  
  - Sets the groundwork for more advanced season lifecycle management features.