### PR TITLE
feat: implemented fixed-amount staking in contract for voter eligibility

### DIFF
--- a/contract_/src/audition/season_and_audition.cairo
+++ b/contract_/src/audition/season_and_audition.cairo
@@ -248,6 +248,37 @@ pub trait ISeasonAndAudition<TContractState> {
     /// @param audition_id the id of the audition to get the aggregate score for
     /// @return a array of (performer_id, aggregate_score)
     fn get_aggregate_score(self: @TContractState, audition_id: felt252) -> Array<(felt252, u256)>;
+
+    /// @notice Sets the staking configuration for an audition.
+    /// @dev Only the owner can call this.
+    /// @param audition_id The ID of the audition.
+    /// @param required_stake_amount The exact amount required for staking.
+    /// @param stake_token The contract address of the token to be used for staking (e.g., USDC).
+    /// @param withdrawal_delay_after_results The time delay for withdrawal after results are final.
+    fn set_staking_config(
+        ref self: TContractState,
+        audition_id: felt252,
+        required_stake_amount: u256,
+        stake_token: ContractAddress,
+        withdrawal_delay_after_results: u64,
+    );
+
+    /// @notice Allows a user to stake tokens to become an eligible voter for an audition.
+    /// @dev The user must send the exact required amount of tokens.
+    /// @param audition_id The ID of the audition to stake for.
+    fn stake_to_vote(ref self: TContractState, audition_id: felt252);
+
+    /// @notice Allows a staker to withdraw their stake after the voting results are finalized.
+    /// @param audition_id The ID of the audition from which to withdraw the stake.
+    fn withdraw_stake_after_results(ref self: TContractState, audition_id: felt252);
+
+    /// @notice Checks if a wallet is eligible to vote for a specific audition.
+    /// @param audition_id The ID of the audition.
+    /// @param voter_address The address of the voter to check.
+    /// @return bool True if the voter is eligible, false otherwise.
+    fn is_eligible_voter(
+        self: @TContractState, audition_id: felt252, voter_address: ContractAddress,
+    ) -> bool;
 }
 
 #[starknet::contract]
@@ -286,6 +317,62 @@ pub mod SeasonAndAudition {
     impl OwnableTwoStepImpl = OwnableComponent::OwnableTwoStepImpl<ContractState>;
     impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
 
+    #[derive(Drop, Serde, starknet::Store)]
+    pub struct StakingConfig {
+        pub required_stake_amount: u256,
+        pub stake_token: ContractAddress,
+        pub withdrawal_delay_after_results: u64,
+    }
+
+    #[derive(Drop, Serde, starknet::Store)]
+    pub struct StakerInfo {
+        pub address: ContractAddress,
+        pub audition_id: felt252,
+        pub staked_amount: u256,
+        pub stake_timestamp: u64,
+        pub is_eligible_voter: bool,
+        pub has_voted: bool,
+    }
+
+    impl StakerInfoImpl of Default<StakerInfo> {
+        fn default() -> StakerInfo {
+            let felt_default: felt252 = Default::default();
+            let u256_default: u256 = Default::default();
+            let u64_default: u64 = Default::default();
+            let bool_default: bool = Default::default();
+
+            StakerInfo {
+                address: 0x0.try_into().unwrap(),
+                audition_id: felt_default,
+                staked_amount: u256_default,
+                stake_timestamp: u64_default,
+                is_eligible_voter: bool_default,
+                has_voted: bool_default,
+            }
+        }
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct StakingConfigSet {
+        audition_id: felt252,
+        required_stake_amount: u256,
+        stake_token: ContractAddress,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct StakePlaced {
+        audition_id: felt252,
+        staker: ContractAddress,
+        amount: u256,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct StakeWithdrawn {
+        audition_id: felt252,
+        staker: ContractAddress,
+        amount: u256,
+    }
+
     #[storage]
     struct Storage {
         whitelisted_oracles: Map<ContractAddress, bool>,
@@ -295,6 +382,12 @@ pub mod SeasonAndAudition {
         global_paused: bool,
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
+        /// @notice Maps an audition ID to its staking configuration.
+        staking_configs: Map<felt252, StakingConfig>,
+        /// @notice Maps (audition_id, staker_address) to the staker's information.
+        stakers: Map<(felt252, ContractAddress), StakerInfo>,
+        /// @notice Tracks which wallets are eligible to vote for a specific audition.
+        eligible_voters: Map<(felt252, ContractAddress), bool>,
         // @notice this storage is a mapping of the audition rpices deposited by the audition
         // owners, Map<audition_id, (token contract address  , amount of the token set as the
         // price)>
@@ -390,6 +483,9 @@ pub mod SeasonAndAudition {
         AggregateScoreCalculated: AggregateScoreCalculated,
         AppealSubmitted: AppealSubmitted,
         AppealResolved: AppealResolved,
+        StakingConfigSet: StakingConfigSet,
+        StakePlaced: StakePlaced,
+        StakeWithdrawn: StakeWithdrawn,
     }
 
     #[constructor]
@@ -1153,6 +1249,101 @@ pub mod SeasonAndAudition {
         }
         fn get_appeal(self: @ContractState, evaluation_id: u256) -> Appeal {
             self.appeals.entry(evaluation_id).read()
+        }
+
+        fn set_staking_config(
+            ref self: ContractState,
+            audition_id: felt252,
+            required_stake_amount: u256,
+            stake_token: ContractAddress,
+            withdrawal_delay_after_results: u64,
+        ) {
+            self.ownable.assert_only_owner();
+            assert(self.audition_exists(audition_id), 'Audition does not exist');
+            assert(!stake_token.is_zero(), 'Stake token cannot be zero');
+            assert(required_stake_amount > 0, 'Stake amount must be > 0');
+
+            let config = StakingConfig {
+                required_stake_amount, stake_token, withdrawal_delay_after_results,
+            };
+            self.staking_configs.write(audition_id, config);
+            self
+                .emit(
+                    Event::StakingConfigSet(
+                        StakingConfigSet { audition_id, required_stake_amount, stake_token },
+                    ),
+                );
+        }
+
+        fn stake_to_vote(ref self: ContractState, audition_id: felt252) {
+            let caller = get_caller_address();
+            let config = self.staking_configs.read(audition_id);
+            let required_amount = config.required_stake_amount;
+
+            assert(required_amount > 0, 'Staking not enabled');
+            assert(!self.is_audition_ended(audition_id), 'Audition has ended');
+            assert(!self.stakers.read((audition_id, caller)).is_eligible_voter, 'Already staked');
+
+            // This internal function handles the token transfer and checks allowance/balance
+            self._process_payment(required_amount, config.stake_token);
+
+            let staker_info = StakerInfo {
+                address: caller,
+                audition_id,
+                staked_amount: required_amount,
+                stake_timestamp: get_block_timestamp(),
+                is_eligible_voter: true,
+                has_voted: false,
+            };
+
+            self.stakers.write((audition_id, caller), staker_info);
+            self.eligible_voters.write((audition_id, caller), true);
+
+            self
+                .emit(
+                    Event::StakePlaced(
+                        StakePlaced { audition_id, staker: caller, amount: required_amount },
+                    ),
+                );
+        }
+
+        fn withdraw_stake_after_results(ref self: ContractState, audition_id: felt252) {
+            let caller = get_caller_address();
+            let staker_info = self.stakers.read((audition_id, caller));
+            let config = self.staking_configs.read(audition_id);
+
+            assert(staker_info.is_eligible_voter, 'No stake to withdraw');
+            assert(self.is_audition_ended(audition_id), 'Audition not yet ended');
+
+            // Optional: Check withdrawal delay
+            let audition = self.auditions.read(audition_id);
+            let end_time: u64 = audition.end_timestamp.try_into().unwrap();
+            assert(
+                get_block_timestamp() >= end_time + config.withdrawal_delay_after_results,
+                'Withdrawal delay active',
+            );
+
+            // Transfer stake back to caller
+            self._send_tokens(caller, staker_info.staked_amount, config.stake_token);
+
+            // Clear staker data
+            self.stakers.entry((audition_id, caller)).write(Default::default());
+            self.eligible_voters.write((audition_id, caller), false);
+
+            self
+                .emit(
+                    Event::StakeWithdrawn(
+                        StakeWithdrawn {
+                            audition_id, staker: caller, amount: staker_info.staked_amount,
+                        },
+                    ),
+                );
+        }
+
+        fn is_eligible_voter(
+            self: @ContractState, audition_id: felt252, voter_address: ContractAddress,
+        ) -> bool {
+            self.eligible_voters.entry((audition_id, voter_address)).read()
         }
     }
 

--- a/contract_/tests/test_season_and_audition.cairo
+++ b/contract_/tests/test_season_and_audition.cairo
@@ -89,6 +89,37 @@ fn create_default_audition(audition_id: felt252, season_id: felt252) -> Audition
     }
 }
 
+// Helper function to set up a standard environment for staking tests
+fn setup_staking_audition() -> (ISeasonAndAuditionDispatcher, IERC20Dispatcher, felt252) {
+    let (contract, _, _) = deploy_contract();
+    let mock_token = deploy_mock_erc20_contract();
+    let audition_id: felt252 = 1;
+    let season_id: felt252 = 1;
+
+    // Create a new audition as the owner
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    let default_audition = create_default_audition(audition_id, season_id);
+    contract
+        .create_audition(
+            audition_id,
+            season_id,
+            default_audition.genre,
+            default_audition.name,
+            default_audition.start_timestamp,
+            // A future end timestamp to ensure it's not ended
+            get_block_timestamp().into() + 1000,
+            default_audition.paused,
+        );
+    stop_cheat_caller_address(contract.contract_address);
+
+    start_cheat_caller_address(mock_token.contract_address, OWNER());
+    // Mint some tokens to user for testing,
+    mock_token.transfer(USER(), 1000000);
+    stop_cheat_caller_address(mock_token.contract_address);
+
+    (contract, mock_token, audition_id)
+}
+
 #[test]
 fn test_season_create() {
     let (contract, _, _) = deploy_contract();
@@ -3511,4 +3542,183 @@ fn test_perform_aggregate_score_calculation_successful() {
     ); // aggregate_score: [(530776410631550129238593, 4), (530776410631550129238594, 6)]
 
     stop_cheat_block_timestamp(contract.contract_address);
+}
+
+// staking to vote tests starts here
+#[test]
+fn test_owner_can_set_and_adjust_stake_amount() {
+    let (contract, mock_token, audition_id) = setup_staking_audition();
+
+    // Owner sets the initial staking configuration
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.set_staking_config(audition_id, 100, mock_token.contract_address, 3600);
+    // You'll need to add a get_staking_config function to the contract to read this, or check via
+    // events.
+    // Assuming an event StakingConfigSet is emitted.
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Owner adjusts the staking configuration
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.set_staking_config(audition_id, 200, mock_token.contract_address, 7200);
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_non_owner_cannot_set_staking_config() {
+    let (contract, mock_token, audition_id) = setup_staking_audition();
+
+    // Non-owner attempts to set the staking configuration
+    start_cheat_caller_address(contract.contract_address, USER());
+    contract.set_staking_config(audition_id, 100, mock_token.contract_address, 3600);
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'Already staked')]
+fn test_prevent_double_staking() {
+    let (contract, mock_token, audition_id) = setup_staking_audition();
+    let stake_amount = 100_u256;
+
+    // Configure staking
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.set_staking_config(audition_id, stake_amount, mock_token.contract_address, 0);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // User approves tokens
+    start_cheat_caller_address(mock_token.contract_address, USER());
+    mock_token.approve(contract.contract_address, stake_amount * 2);
+    stop_cheat_caller_address(mock_token.contract_address);
+
+    // First stake (successful)
+    start_cheat_caller_address(contract.contract_address, USER());
+    contract.stake_to_vote(audition_id);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Second stake (should panic)
+    start_cheat_caller_address(contract.contract_address, USER());
+    contract.stake_to_vote(audition_id);
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+#[test]
+fn test_eligibility_tracking_and_stake_locking() {
+    let (contract, mock_token, audition_id) = setup_staking_audition();
+    let stake_amount = 100_u256;
+
+    // 1. Set config
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.set_staking_config(audition_id, stake_amount, mock_token.contract_address, 3600);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // 2. Check eligibility before staking
+    assert!(!contract.is_eligible_voter(audition_id, USER()), "Should not be eligible yet");
+
+    // 3. Approve and stake
+    start_cheat_caller_address(mock_token.contract_address, USER());
+    mock_token.approve(contract.contract_address, stake_amount);
+    stop_cheat_caller_address(mock_token.contract_address);
+
+    start_cheat_caller_address(contract.contract_address, USER());
+    contract.stake_to_vote(audition_id);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // 4. Check eligibility after staking
+    assert!(contract.is_eligible_voter(audition_id, USER()), "Should be eligible after stake");
+}
+
+#[test]
+#[should_panic(expected: 'Audition not yet ended')]
+fn test_stake_is_locked_before_results() {
+    let (contract, mock_token, audition_id) = setup_staking_audition();
+    let stake_amount = 100_u256;
+
+    // Set config
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.set_staking_config(audition_id, stake_amount, mock_token.contract_address, 3600);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Approve and stake
+    start_cheat_caller_address(mock_token.contract_address, USER());
+    mock_token.approve(contract.contract_address, stake_amount);
+    stop_cheat_caller_address(mock_token.contract_address);
+
+    start_cheat_caller_address(contract.contract_address, USER());
+    contract.stake_to_vote(audition_id);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Attempt to withdraw before audition has ended
+    start_cheat_caller_address(contract.contract_address, USER());
+    contract.withdraw_stake_after_results(audition_id);
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+#[test]
+fn test_successful_withdrawal_after_results() {
+    let (contract, mock_token, audition_id) = setup_staking_audition();
+    let stake_amount = 100_u256;
+    let withdrawal_delay = 3600_u64;
+
+    // Set config
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract
+        .set_staking_config(
+            audition_id, stake_amount, mock_token.contract_address, withdrawal_delay,
+        );
+    stop_cheat_caller_address(contract.contract_address);
+
+    // User approves and stakes
+    start_cheat_caller_address(mock_token.contract_address, USER());
+    mock_token.approve(contract.contract_address, stake_amount);
+    stop_cheat_caller_address(mock_token.contract_address);
+
+    start_cheat_caller_address(contract.contract_address, USER());
+    contract.stake_to_vote(audition_id);
+    stop_cheat_caller_address(contract.contract_address);
+
+    let user_balance_before_withdrawal = mock_token.balance_of(USER().into());
+
+    // Owner ends the audition
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    // set block timestamp to non zero, it's zero by default
+    start_cheat_block_timestamp(contract.contract_address, 1);
+    contract.end_audition(audition_id);
+
+    // Advance time past the withdrawal delay
+    let audition_end_time = get_block_timestamp();
+    start_cheat_block_timestamp(
+        contract.contract_address, audition_end_time + withdrawal_delay + 1,
+    );
+    stop_cheat_caller_address(contract.contract_address);
+
+    // User withdraws stake
+    start_cheat_caller_address(contract.contract_address, USER());
+    contract.withdraw_stake_after_results(audition_id);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Assertions
+    let user_balance_after_withdrawal = mock_token.balance_of(USER().into());
+    assert!(
+        user_balance_after_withdrawal == user_balance_before_withdrawal + stake_amount,
+        "User balance not refunded",
+    );
+    assert!(!contract.is_eligible_voter(audition_id, USER()), "Eligibility should be revoked");
+}
+
+#[test]
+#[should_panic(expected: 'No stake to withdraw')]
+fn test_failed_withdrawal_if_not_staked() {
+    let (contract, mock_token, audition_id) = setup_staking_audition();
+
+    // Set config
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.set_staking_config(audition_id, 100, mock_token.contract_address, 0);
+    // End the audition immediately for testing withdrawal
+    contract.end_audition(audition_id);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // A user who never staked tries to withdraw
+    start_cheat_caller_address(contract.contract_address, USER());
+    contract.withdraw_stake_after_results(audition_id);
+    stop_cheat_caller_address(contract.contract_address);
 }


### PR DESCRIPTION
This PR introduces a staking system for voters. To vote in an audition, users must now stake a fixed token amount set by the owner.

**Core Logic:**
- Owner sets the required stake amount for an audition.
- Voters stake the exact amount to become eligible to vote.
- Stakes are locked until the audition is over, after which they can be withdrawn.
- 
**Changes:**
- Contract: Added `set_staking_config`, `stake_to_vote`, and `withdraw_stake_after_results` functions.
- Tests: Included tests for staking, withdrawal, and all edge cases.

Closes: #101 
