### PR TITLE
fix(ui): Correctly display audition ID in analytics header

### DIFF
--- a/webapp/app/audition/[auditionId]/analytics/page.tsx
+++ b/webapp/app/audition/[auditionId]/analytics/page.tsx
@@ -31,7 +31,7 @@ export default function AnalyticsPage() {
         <header className="mb-8">
           <h1 className="text-2xl font-bold text-white">Audition Analytics</h1>
           <p className="mt-2 text-lg text-slate-300">
-            Detailed voting analysis for audition #[auditionId]
+            Detailed voting analysis for audition #{auditionId}
           </p>
         </header>
 


### PR DESCRIPTION
The header on the analytics page was displaying the literal string
`#[auditionId]` instead of the dynamic audition ID from the URL.
This was caused by an incorrect string interpolation syntax.
